### PR TITLE
[#11]feat: 추가한 Todo 렌더링 구현

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,9 +2,8 @@
   <div id="app">
     <div class="todo-wrapper">
       <Header />
-      <!-- v-on:하위 컴포넌트에서 발생시킨 이벤트 이름="현재 컴포넌트 메서드 명" -->
       <Input v-on:onAddTodo="handleAddTodo" />
-      <List />
+      <List v-bind:todos="todos" />
     </div>
   </div>
 </template>
@@ -26,6 +25,19 @@ export default {
     return {
       todos: [],
     };
+  },
+
+  created() {
+    if (localStorage.length !== 0) {
+      for (let i = 0; i < localStorage.length; i += 1) {
+        if (localStorage.key(i) !== "loglevel:webpack-dev-server") {
+          this.todos = [
+            ...this.todos,
+            JSON.parse(localStorage.getItem(localStorage.key(i))),
+          ];
+        }
+      }
+    }
   },
 
   methods: {

--- a/src/components/List.vue
+++ b/src/components/List.vue
@@ -1,14 +1,16 @@
 <template>
   <section class="main">
     <ul class="todo-list">
-      <li>todo</li>
-      <!-- <li></li> ...  -->
+      <li v-for="{ id, text } in todos" :key="id">{{ text }}</li>
     </ul>
   </section>
 </template>
 
 <script>
-export default {};
+export default {
+  props: ["todos"],
+  methods: {},
+};
 </script>
 
 <style scoped>


### PR DESCRIPTION
> close #11 

## 종류

<!-- PR 종류를 선택하세요 -->

- [ ] Code Review
- [x] New Feature
- [ ] Bug Fix
- [ ] CI / CD
- [ ] Setup

## 내용

<!-- - 내용 명: 내용을 작성합니다. -->
- v-bind를 활용하여 상위 객체에 있는 상태값인 todos를 바인딩 하여 하위 객체로 넘김
- 위 방식으로 넘긴 데이터를 props로 받아서 활용
- v-for를 사용하여 todos에 담긴 객체를 반복하여 li Element를 렌더링, 이 때 key 값을 항상 가지고 있음
- input에서 추가된 할 일을 localStorage에 저장 후 렌더링 전 create시 todo에 복사

## 체크리스트

<!-- - [ ] 체크리스트를 작성합니다. -->
- [x] 바인딩 된 props를 잘 받아 오는가 ?
- [x] mount 전 create를 통해 localStorage에 있는 데이터를 가져오는가 ?
- [x] localStorage에 있는 할 일들이 잘 렌더링 되는가 ?